### PR TITLE
add Node.js 4.x to .travis.yml

### DIFF
--- a/generators/app/templates/travisyml
+++ b/generators/app/templates/travisyml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - stable
+  - '4'
   - '0.12'
   - '0.10'


### PR DESCRIPTION
`stable` now points to `5.x`
