### PR TITLE
Only support active LTS node versions (Fix #11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - v7
-  - v6
-  - v5
-  - v4
-  - '0.12'
+  - 7
+  - 6
+  - 4

--- a/generators/app/templates/travisyml
+++ b/generators/app/templates/travisyml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - v7
-  - v6
-  - v5
-  - v4
-  - '0.12'
+  - 7
+  - 6
+  - 4


### PR DESCRIPTION
1. Let's drop Node 0.12 and 5 (they're not officially maintained anymore)
2. Drop the `v` so tools like Trevor will work fine